### PR TITLE
Set element to work on Firefox

### DIFF
--- a/LICENSE-BSD.txt
+++ b/LICENSE-BSD.txt
@@ -1,0 +1,7 @@
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+* The names of its contributors may not be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/universal-citekey.js
+++ b/universal-citekey.js
@@ -45,9 +45,9 @@ function update_universal_citekeydisplay(argument)
 	var uc_span = document.getElementById('universal-citekey-output');
 	var uc_doi_span = document.getElementById('uc-doi-output');
 	var uc_title_span = document.getElementById('uc-title-output');
-	uc_span.innerText = uc;
-	uc_doi_span.innerText   = uc_doi;
-	uc_title_span.innerText = uc_title;
+	uc_span.innerHTML = uc;
+	uc_doi_span.innerHTML   = uc_doi;
+	uc_title_span.innerHTML = uc_title;
 }
 
 


### PR DESCRIPTION
Change the automatic update to work on Firefox. Setting `innerText`
would never update on FF. Used `innerHTML` instead.

Tested on Mac
- Firefox
- Google Chrome
- Safari

Tested on Windows 7
- Firefox
- Google Chrome
